### PR TITLE
Yuning manage members design

### DIFF
--- a/app/assets/stylesheets/components/containers.css
+++ b/app/assets/stylesheets/components/containers.css
@@ -16,8 +16,8 @@ body {
   border-radius: 20px;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: space-around;
+  /* align-items: center; */
+  /* justify-content: space-around; */
   box-shadow: 5px 2px 5px #00000020;
   gap: 10px;
 }

--- a/app/assets/stylesheets/managemembers.css
+++ b/app/assets/stylesheets/managemembers.css
@@ -14,7 +14,12 @@
 }
 
 .table-title {
-    border-style: none;   
+  border-style: none;   
+}
+
+.caption-text {
+  text-align: center;
+  font-size: 22px;
 }
 
 .pink_button {

--- a/app/assets/stylesheets/managemembers.css
+++ b/app/assets/stylesheets/managemembers.css
@@ -2,8 +2,14 @@
 @import url("./components/fancy_headers.css");
 @import url("./components/buttons.css");
 
-table {
+
+.table-class {
+    border-collapse: separate;
     background-color: white;
+    border-radius: 20px;
+    margin: auto;
+    border: 1px solid black;
+    padding: 20px;
 }
 
 .table-title {
@@ -22,5 +28,5 @@ table {
 
   padding-top: 50px;
   padding-bottom: 50px;
-  gap: 10px;
+  
 }

--- a/app/assets/stylesheets/managemembers.css
+++ b/app/assets/stylesheets/managemembers.css
@@ -10,6 +10,7 @@
     margin: auto;
     border: 1px solid black;
     padding: 20px;
+    
 }
 
 .table-title {
@@ -29,4 +30,52 @@
   padding-top: 50px;
   padding-bottom: 50px;
   
+}
+  
+@media (max-width: 825px) {
+  .pink_button {
+    width: 100px;
+  }
+
+  table {
+    border: 0;
+  }
+  
+  table thead {
+    border: none;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+  }
+  
+  table tr {
+    border-bottom: 1px solid grey;
+    display: block;
+    margin-bottom: .625em;
+  }
+  
+  table td {
+    border-bottom: 1px solid #ddd;
+    display: block;
+    font-size: .8em;
+    text-align: right;
+  }
+  
+  table td::before {
+    
+    content: attr(data-label);
+    font-family: "Sansita One";
+    float: left;
+    font-weight: bold;
+    font-size: 22px;
+    
+  }
+  
+  table td:last-child {
+    border-bottom: 0;
+  }
 }

--- a/app/assets/stylesheets/managemembers.css
+++ b/app/assets/stylesheets/managemembers.css
@@ -78,4 +78,8 @@
   table td:last-child {
     border-bottom: 0;
   }
+
+  table tr:last-child {
+    border-bottom: 0;
+  }
 }

--- a/app/assets/stylesheets/managemembers.css
+++ b/app/assets/stylesheets/managemembers.css
@@ -1,4 +1,6 @@
+@import url("./components/containers.css");
+@import url("./components/fancy_headers.css");
+
 table {
-    background-color:#F5D7CD;
-    font-family: Sansita One;
+    background-color: white;
 }

--- a/app/assets/stylesheets/managemembers.css
+++ b/app/assets/stylesheets/managemembers.css
@@ -1,0 +1,4 @@
+table {
+    background-color:#F5D7CD;
+    font-family: Sansita One;
+}

--- a/app/assets/stylesheets/managemembers.css
+++ b/app/assets/stylesheets/managemembers.css
@@ -1,6 +1,26 @@
 @import url("./components/containers.css");
 @import url("./components/fancy_headers.css");
+@import url("./components/buttons.css");
 
 table {
     background-color: white;
+}
+
+.table-title {
+    border-style: none;   
+}
+
+.pink_button {
+    margin-top: 0px;
+}
+
+.box {
+    margin: 30px 30px 30px 30px;
+}
+
+.manage-container {
+
+  padding-top: 50px;
+  padding-bottom: 50px;
+  gap: 10px;
 }

--- a/app/views/admin/manage_members.html.erb
+++ b/app/views/admin/manage_members.html.erb
@@ -63,7 +63,7 @@
           <tr id=<%= "member_row_#{user.id}" %>>
             <td><%= user.full_name %></td>
             <td><%= user.email %></td>
-            <td><%= link_to get_points(user), "/show_user_attendance/#{user.id}" %></td>
+            <td><%= link_to get_points(user), "/show_user_attendance/#{user.id}", class:'pink-link' %></td>
             <td><%= get_user_status(user) %>
             <td>
               <div class="dropdown">

--- a/app/views/admin/manage_members.html.erb
+++ b/app/views/admin/manage_members.html.erb
@@ -1,15 +1,20 @@
 <%= stylesheet_link_tag "managemembers" %>
 
+
+
+
 <div class="manage-container">
 
 <h1>Manage Members</h1>
 <p class="center">You can manage members here.</p>
 
 
+
+
 <div class="box">
   <h1 class="table-title">New Users</h1>
   <% if @new_users.length > 0 %>
-    <table class="table border border-dark table-borderless">
+    <table class="table table-borderless table-class">
 
     <th><h2>Name</h2></th>
     <th><h2>Email</h2></th>
@@ -40,17 +45,17 @@
       <% end %>
     </tbody>
   </table>
-<% else %>
-  <p>No new users.</p>
-<% end %>
+  <% else %>
+    <p>No new users.</p>
+  <% end %>
 </div>
 
 <div class="box">
   <h1 class="table-title">Members</h1>
   <% if @members.length > 0 %>
-
   
-    <table class="table border border-dark table-borderless">
+  <div style="overflow-x:auto, overflow-y:visible">
+    <table class="table table-borderless table-class">
       <thead>
         <th><h2>Name</h2></th>
         <th><h2>Email</h2></th>
@@ -98,7 +103,7 @@
         <% end %>
       </tbody>
     </table>
-  
+  </div>
   <% else %>
     <p>No members.</p>
   <% end %>
@@ -107,7 +112,7 @@
 <div class="box">
   <h1 class="table-title">Alumni</h1>
   <% if @alumni.length > 0 %>
-    <table class="table border border-dark table-borderless">
+    <table class="table table-borderless table-class">
       <thead>
         <th><h2>Name</h2></th>
         <th><h2>Email</h2></th>
@@ -159,4 +164,5 @@
     <p>No alumni.</p>
   <% end %>
 </div>
+
 </div>

--- a/app/views/admin/manage_members.html.erb
+++ b/app/views/admin/manage_members.html.erb
@@ -3,146 +3,152 @@
 <h1>Manage Members</h1>
 <p>You can manage members here.</p>
 
-<h2>New Users</h2>
-<% if @new_users.length > 0 %>
-  <table>
-    <th>Name</th>
-    <th>Email</th>
-    <th>Actions</th>
-    <tbody>
-      <% @new_users.each do |user| %>
-        <tr id=<%= "new_user_row_#{user.id}" %>>
-          <td><%= user.full_name %></td>
-          <td><%= user.email %></td>
-          <td>
-            <div class="dropdown">
-              <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                Manage
-              </button>
-              <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-                <%# option to give user member status %>
-                <li><%= link_to "Make Member", "/make_user_member/#{user.id}", class: "dropdown-item" %></li>
-                <%# option to give user alumni status %>
-                <li><%= link_to "Make Alumni", "/make_user_alumni/#{user.id}", class: "dropdown-item" %></li>
-                <%# option to give user admin status %>
-                <li><%= link_to "Make Admin", "/make_user_admin/#{user.id}", class: "dropdown-item" %></li>
-                <%# option to delete user %>
-                <li><%= link_to "Delete User", "/delete_user/#{user.id}", class: "dropdown-item" %></li>
-              </ul>
-            </div>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
-<% else %>
-  <p>No new users.</p>
-<% end %>
-
-<h2>Members</h2>
-<% if @members.length > 0 %>
-  <table class="table">
-    <thead>
+<div class="box">
+  <h2>New Users</h2>
+  <% if @new_users.length > 0 %>
+    <table>
       <th>Name</th>
       <th>Email</th>
-      <th>Points</th>
-      <th>Member Status</th>
       <th>Actions</th>
-    </thead>
-    <tbody>
-      <% @members.each do |user| %>
-        <tr id=<%= "member_row_#{user.id}" %>>
-          <td><%= user.full_name %></td>
-          <td><%= user.email %></td>
-          <td><%= link_to get_points(user), "/show_user_attendance/#{user.id}" %></td>
-          <td><%= get_user_status(user) %>
-          <td>
-            <div class="dropdown">
-              <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                Manage
-              </button>
-              <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-                <% if !user.admin %>
-                  <%# option to give user admin status %>
-                  <li><%= link_to "Make Admin", "/make_user_admin/#{user.id}", class: "dropdown-item" %></li>
-                <% else %>
-                  <%# option to give user member status %>
-                  <li><%= link_to "Remove Admin Status", "/make_user_member/#{user.id}", class: "dropdown-item" %></li>
-                <% end %>
-                <% if !user.member %>
+      <tbody>
+        <% @new_users.each do |user| %>
+          <tr id=<%= "new_user_row_#{user.id}" %>>
+            <td><%= user.full_name %></td>
+            <td><%= user.email %></td>
+            <td>
+              <div class="dropdown">
+                <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                  Manage
+                </button>
+                <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton">
                   <%# option to give user member status %>
                   <li><%= link_to "Make Member", "/make_user_member/#{user.id}", class: "dropdown-item" %></li>
-                <% end %>
-                <% if !user.alumni %>
                   <%# option to give user alumni status %>
                   <li><%= link_to "Make Alumni", "/make_user_alumni/#{user.id}", class: "dropdown-item" %></li>
-                <% else %>
-                  <%# option to give user member status %>
-                  <li><%= link_to "Remove Alumni Status", "/make_user_member/#{user.id}", class: "dropdown-item" %></li>
-                <% end %>
-                <%# option to take away user's member status %>
-                <li><%= link_to "Remove Member Status", "/remove_user_member/#{user.id}", class: "dropdown-item" %></li>
-              </ul>
-            </div>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
-<% else %>
-  <p>No members.</p>
-<% end %>
+                  <%# option to give user admin status %>
+                  <li><%= link_to "Make Admin", "/make_user_admin/#{user.id}", class: "dropdown-item" %></li>
+                  <%# option to delete user %>
+                  <li><%= link_to "Delete User", "/delete_user/#{user.id}", class: "dropdown-item" %></li>
+                </ul>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <p>No new users.</p>
+  <% end %>
+</div>
 
-<h2>Alumni</h2>
-<% if @alumni.length > 0 %>
-  <table>
-    <thead>
-      <th>Name</th>
-      <th>Email</th>
-      <th>Points</th>
-      <th>Member Status</th>
-      <th>Actions</th>
-    </thead>
-    <tbody>
-      <% @alumni.each do |user| %>
-        <tr id=<%= "member_row_#{user.id}" %>>
-          <td><%= user.full_name %></td>
-          <td><%= user.email %></td>
-          <td><%= user.information.points %></td>
-          <td><%= get_user_status(user) %>
-          <td>
-            <div class="dropdown">
-              <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                Manage
-              </button>
-              <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-                <% if !user.admin %>
-                  <%# option to give user admin status %>
-                  <li><%= link_to "Make Admin", "/make_user_admin/#{user.id}", class: "dropdown-item" %></li>
-                <% else %>
-                  <%# option to give user member status %>
-                  <li><%= link_to "Remove Admin Status", "/make_user_member/#{user.id}", class: "dropdown-item" %></li>
-                <% end %>
-                <% if !user.member %>
-                  <%# option to give user member status %>
-                  <li><%= link_to "Make Member", "/make_user_member/#{user.id}", class: "dropdown-item" %></li>
-                <% end %>
-                <% if !user.alumni %>
-                  <%# option to give user alumni status %>
-                  <li><%= link_to "Make Alumni", "/make_user_alumni/#{user.id}", class: "dropdown-item" %></li>
-                <% else %>
-                  <%# option to give user member status %>
-                  <li><%= link_to "Remove Alumni Status", "/make_user_member/#{user.id}", class: "dropdown-item" %></li>
-                <% end %>
-                <%# option to take away user's member status %>
-                <li><%= link_to "Remove Member Status", "/remove_user_member/#{user.id}", class: "dropdown-item" %></li>
-              </ul>
-            </div>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
-<% else %>
-  <p>No alumni.</p>
-<% end %>
+<div class="box">
+  <h2>Members</h2>
+  <% if @members.length > 0 %>
+    <table class="table">
+      <thead>
+        <th>Name</th>
+        <th>Email</th>
+        <th>Points</th>
+        <th>Member Status</th>
+        <th>Actions</th>
+      </thead>
+      <tbody>
+        <% @members.each do |user| %>
+          <tr id=<%= "member_row_#{user.id}" %>>
+            <td><%= user.full_name %></td>
+            <td><%= user.email %></td>
+            <td><%= link_to get_points(user), "/show_user_attendance/#{user.id}" %></td>
+            <td><%= get_user_status(user) %>
+            <td>
+              <div class="dropdown">
+                <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                  Manage
+                </button>
+                <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                  <% if !user.admin %>
+                    <%# option to give user admin status %>
+                    <li><%= link_to "Make Admin", "/make_user_admin/#{user.id}", class: "dropdown-item" %></li>
+                  <% else %>
+                    <%# option to give user member status %>
+                    <li><%= link_to "Remove Admin Status", "/make_user_member/#{user.id}", class: "dropdown-item" %></li>
+                  <% end %>
+                  <% if !user.member %>
+                    <%# option to give user member status %>
+                    <li><%= link_to "Make Member", "/make_user_member/#{user.id}", class: "dropdown-item" %></li>
+                  <% end %>
+                  <% if !user.alumni %>
+                    <%# option to give user alumni status %>
+                    <li><%= link_to "Make Alumni", "/make_user_alumni/#{user.id}", class: "dropdown-item" %></li>
+                  <% else %>
+                    <%# option to give user member status %>
+                    <li><%= link_to "Remove Alumni Status", "/make_user_member/#{user.id}", class: "dropdown-item" %></li>
+                  <% end %>
+                  <%# option to take away user's member status %>
+                  <li><%= link_to "Remove Member Status", "/remove_user_member/#{user.id}", class: "dropdown-item" %></li>
+                </ul>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <p>No members.</p>
+  <% end %>
+</div>
+
+<div class="box">
+  <h2>Alumni</h2>
+  <% if @alumni.length > 0 %>
+    <table>
+      <thead>
+        <th>Name</th>
+        <th>Email</th>
+        <th>Points</th>
+        <th>Member Status</th>
+        <th>Actions</th>
+      </thead>
+      <tbody>
+        <% @alumni.each do |user| %>
+          <tr id=<%= "member_row_#{user.id}" %>>
+            <td><%= user.full_name %></td>
+            <td><%= user.email %></td>
+            <td><%= user.information.points %></td>
+            <td><%= get_user_status(user) %>
+            <td>
+              <div class="dropdown">
+                <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                  Manage
+                </button>
+                <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                  <% if !user.admin %>
+                    <%# option to give user admin status %>
+                    <li><%= link_to "Make Admin", "/make_user_admin/#{user.id}", class: "dropdown-item" %></li>
+                  <% else %>
+                    <%# option to give user member status %>
+                    <li><%= link_to "Remove Admin Status", "/make_user_member/#{user.id}", class: "dropdown-item" %></li>
+                  <% end %>
+                  <% if !user.member %>
+                    <%# option to give user member status %>
+                    <li><%= link_to "Make Member", "/make_user_member/#{user.id}", class: "dropdown-item" %></li>
+                  <% end %>
+                  <% if !user.alumni %>
+                    <%# option to give user alumni status %>
+                    <li><%= link_to "Make Alumni", "/make_user_alumni/#{user.id}", class: "dropdown-item" %></li>
+                  <% else %>
+                    <%# option to give user member status %>
+                    <li><%= link_to "Remove Alumni Status", "/make_user_member/#{user.id}", class: "dropdown-item" %></li>
+                  <% end %>
+                  <%# option to take away user's member status %>
+                  <li><%= link_to "Remove Member Status", "/remove_user_member/#{user.id}", class: "dropdown-item" %></li>
+                </ul>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <p>No alumni.</p>
+  <% end %>
+</div>

--- a/app/views/admin/manage_members.html.erb
+++ b/app/views/admin/manage_members.html.erb
@@ -1,16 +1,19 @@
 <%= stylesheet_link_tag "managemembers" %>
 
+<div class="manage-container">
+
 <h1>Manage Members</h1>
-<p>You can manage members here.</p>
+<p class="center">You can manage members here.</p>
+
 
 <div class="box">
-  <h2>New Users</h2>
+  <h1 class="table-title">New Users</h1>
   <% if @new_users.length > 0 %>
-    <table>
+    <table class="table border border-dark table-borderless">
 
-    <th>Name</th>
-    <th>Email</th>
-    <th>Actions</th>
+    <th><h2>Name</h2></th>
+    <th><h2>Email</h2></th>
+    <th><h2>Actions</h2></th>
     <tbody>
       <% @new_users.each do |user| %>
         <tr id=<%= "new_user_row_#{user.id}" %>>
@@ -18,7 +21,7 @@
           <td><%= user.email %></td>
           <td>
             <div class="dropdown">
-              <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <button class="pink_button dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Manage
               </button>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton">
@@ -43,15 +46,17 @@
 </div>
 
 <div class="box">
-  <h2>Members</h2>
+  <h1 class="table-title">Members</h1>
   <% if @members.length > 0 %>
-    <table class="table">
+
+  
+    <table class="table border border-dark table-borderless">
       <thead>
-        <th>Name</th>
-        <th>Email</th>
-        <th>Points</th>
-        <th>Member Status</th>
-        <th>Actions</th>
+        <th><h2>Name</h2></th>
+        <th><h2>Email</h2></th>
+        <th><h2>Points</h2></th>
+        <th><h2>Member Status</h2></th>
+        <th><h2>Actions </h2></th>
       </thead>
       <tbody>
         <% @members.each do |user| %>
@@ -62,7 +67,7 @@
             <td><%= get_user_status(user) %>
             <td>
               <div class="dropdown">
-                <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <button class="pink_button dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                   Manage
                 </button>
                 <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton">
@@ -93,21 +98,22 @@
         <% end %>
       </tbody>
     </table>
+  
   <% else %>
     <p>No members.</p>
   <% end %>
 </div>
 
 <div class="box">
-  <h2>Alumni</h2>
+  <h1 class="table-title">Alumni</h1>
   <% if @alumni.length > 0 %>
-    <table>
+    <table class="table border border-dark table-borderless">
       <thead>
-        <th>Name</th>
-        <th>Email</th>
-        <th>Points</th>
-        <th>Member Status</th>
-        <th>Actions</th>
+        <th><h2>Name</h2></th>
+        <th><h2>Email</h2></th>
+        <th><h2>Points</h2></th>
+        <th><h2>Member Status</h2></th>
+        <th><h2>Actions</h2></th>
       </thead>
       <tbody>
         <% @alumni.each do |user| %>
@@ -118,7 +124,7 @@
             <td><%= get_user_status(user) %>
             <td>
               <div class="dropdown">
-                <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <button class="pink_button dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                   Manage
                 </button>
                 <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton">
@@ -152,4 +158,5 @@
   <% else %>
     <p>No alumni.</p>
   <% end %>
+</div>
 </div>

--- a/app/views/admin/manage_members.html.erb
+++ b/app/views/admin/manage_members.html.erb
@@ -3,8 +3,7 @@
 <div class="manage-container">
 
 <h1>Manage Members</h1>
-<p class="center">You can manage members here.</p>
-
+<p class="caption-text">You can manage members here.</p>
 
 <div class="box">
   <h1 class="table-title">New Users</h1>
@@ -47,7 +46,7 @@
     </table>
  
   <% else %>
-    <p>No new users.</p>
+    <p class="caption-text">No new users.</p>
   <% end %>
 </div>
 
@@ -107,7 +106,7 @@
   
   
   <% else %>
-    <p>No members.</p>
+    <p class="caption-text">No members.</p>
   <% end %>
 </div>
 
@@ -167,7 +166,7 @@
     </table>
 
   <% else %>
-    <p>No alumni.</p>
+    <p class="caption-text">No alumni.</p>
   <% end %>
 
 

--- a/app/views/admin/manage_members.html.erb
+++ b/app/views/admin/manage_members.html.erb
@@ -9,19 +9,23 @@
 <div class="box">
   <h1 class="table-title">New Users</h1>
   <% if @new_users.length > 0 %>
-  <div style="overflow-x:auto, overflow-y:visible">
+  
     <table class="table table-borderless table-class">
-
+    <thead>
+    <tr>
       <th><h2>Name</h2></th>
       <th><h2>Email</h2></th>
       <th><h2>Actions</h2></th>
+    
+    </tr>
+    </thead>
       <tbody>
         <% @new_users.each do |user| %>
           <tr id=<%= "new_user_row_#{user.id}" %>>
-            <td><%= user.full_name %></td>
-            <td><%= user.email %></td>
+            <td scope="row" data-label="Name"><%= user.full_name %></td>
+            <td data-label="Email"><%= user.email %></td>
             <td>
-              <div class="dropdown">
+              <div class="btn-group dropdown">
                 <button class="pink_button dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                   Manage
                 </button>
@@ -41,7 +45,7 @@
         <% end %>
       </tbody>
     </table>
-  </div>
+ 
   <% else %>
     <p>No new users.</p>
   <% end %>
@@ -110,24 +114,26 @@
 <div class="box">
   <h1 class="table-title">Alumni</h1>
   <% if @alumni.length > 0 %>
-  <div style="overflow-x:auto, overflow-y:visible">
+  
     <table class="table table-borderless table-class">
       <thead>
+      <tr>
         <th><h2>Name</h2></th>
         <th><h2>Email</h2></th>
         <th><h2>Points</h2></th>
         <th><h2>Member Status</h2></th>
         <th><h2>Actions</h2></th>
+      </tr>  
       </thead>
       <tbody>
         <% @alumni.each do |user| %>
           <tr id=<%= "member_row_#{user.id}" %>>
-            <td><%= user.full_name %></td>
-            <td><%= user.email %></td>
-            <td><%= user.information.points %></td>
-            <td><%= get_user_status(user) %>
-            <td>
-              <div class="dropdown">
+            <td scope="row" data-label="Name"><%= user.full_name %></td>
+            <td data-label="Email"><%= user.email %></td>
+            <td data-label="Points"><%= user.information.points %></td>
+            <td data-label="Member Status"><%= get_user_status(user) %>
+            <td data-label="Actions">
+              <div class="btn-group dropdown">
                 <button class="pink_button dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                   Manage
                 </button>
@@ -159,7 +165,7 @@
         <% end %>
       </tbody>
     </table>
-  </div>
+
   <% else %>
     <p>No alumni.</p>
   <% end %>

--- a/app/views/admin/manage_members.html.erb
+++ b/app/views/admin/manage_members.html.erb
@@ -1,3 +1,5 @@
+<%= stylesheet_link_tag "managemembers" %>
+
 <h1>Manage Members</h1>
 <p>You can manage members here.</p>
 
@@ -39,7 +41,7 @@
 
 <h2>Members</h2>
 <% if @members.length > 0 %>
-  <table>
+  <table class="table">
     <thead>
       <th>Name</th>
       <th>Email</th>

--- a/app/views/admin/manage_members.html.erb
+++ b/app/views/admin/manage_members.html.erb
@@ -1,50 +1,47 @@
 <%= stylesheet_link_tag "managemembers" %>
 
-
-
-
 <div class="manage-container">
 
 <h1>Manage Members</h1>
 <p class="center">You can manage members here.</p>
 
 
-
-
 <div class="box">
   <h1 class="table-title">New Users</h1>
   <% if @new_users.length > 0 %>
+  <div style="overflow-x:auto, overflow-y:visible">
     <table class="table table-borderless table-class">
 
-    <th><h2>Name</h2></th>
-    <th><h2>Email</h2></th>
-    <th><h2>Actions</h2></th>
-    <tbody>
-      <% @new_users.each do |user| %>
-        <tr id=<%= "new_user_row_#{user.id}" %>>
-          <td><%= user.full_name %></td>
-          <td><%= user.email %></td>
-          <td>
-            <div class="dropdown">
-              <button class="pink_button dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                Manage
-              </button>
-              <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-                <%# option to give user member status %>
-                <li><%= link_to "Make Member", "/make_user_member/#{user.id}", class: "dropdown-item" %></li>
-                <%# option to give user alumni status %>
-                <li><%= link_to "Make Alumni", "/make_user_alumni/#{user.id}", class: "dropdown-item" %></li>
-                <%# option to give user admin status %>
-                <li><%= link_to "Make Admin", "/make_user_admin/#{user.id}", class: "dropdown-item" %></li>
-                <%# option to delete user %>
-                <li><%= link_to "Delete User", "/delete_user/#{user.id}", class: "dropdown-item" %></li>
-              </ul>
-            </div>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
+      <th><h2>Name</h2></th>
+      <th><h2>Email</h2></th>
+      <th><h2>Actions</h2></th>
+      <tbody>
+        <% @new_users.each do |user| %>
+          <tr id=<%= "new_user_row_#{user.id}" %>>
+            <td><%= user.full_name %></td>
+            <td><%= user.email %></td>
+            <td>
+              <div class="dropdown">
+                <button class="pink_button dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                  Manage
+                </button>
+                <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                  <%# option to give user member status %>
+                  <li><%= link_to "Make Member", "/make_user_member/#{user.id}", class: "dropdown-item" %></li>
+                  <%# option to give user alumni status %>
+                  <li><%= link_to "Make Alumni", "/make_user_alumni/#{user.id}", class: "dropdown-item" %></li>
+                  <%# option to give user admin status %>
+                  <li><%= link_to "Make Admin", "/make_user_admin/#{user.id}", class: "dropdown-item" %></li>
+                  <%# option to delete user %>
+                  <li><%= link_to "Delete User", "/delete_user/#{user.id}", class: "dropdown-item" %></li>
+                </ul>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
   <% else %>
     <p>No new users.</p>
   <% end %>
@@ -53,25 +50,25 @@
 <div class="box">
   <h1 class="table-title">Members</h1>
   <% if @members.length > 0 %>
-  
-  <div style="overflow-x:auto, overflow-y:visible">
     <table class="table table-borderless table-class">
       <thead>
+      <tr>
         <th><h2>Name</h2></th>
         <th><h2>Email</h2></th>
         <th><h2>Points</h2></th>
         <th><h2>Member Status</h2></th>
         <th><h2>Actions </h2></th>
+      </tr>
       </thead>
       <tbody>
         <% @members.each do |user| %>
           <tr id=<%= "member_row_#{user.id}" %>>
-            <td><%= user.full_name %></td>
-            <td><%= user.email %></td>
-            <td><%= link_to get_points(user), "/show_user_attendance/#{user.id}", class:'pink-link' %></td>
-            <td><%= get_user_status(user) %>
-            <td>
-              <div class="dropdown">
+            <td scope="row" data-label="Name"><%= user.full_name %></td>
+            <td data-label="Email"><%= user.email %></td>
+            <td data-label="Points"><%= link_to get_points(user), "/show_user_attendance/#{user.id}", class:'pink-link' %></td>
+            <td data-label="Member Status"><%= get_user_status(user) %>
+            <td data-label="Actions">
+              <div class="btn-group dropdown">
                 <button class="pink_button dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                   Manage
                 </button>
@@ -103,7 +100,8 @@
         <% end %>
       </tbody>
     </table>
-  </div>
+  
+  
   <% else %>
     <p>No members.</p>
   <% end %>
@@ -112,6 +110,7 @@
 <div class="box">
   <h1 class="table-title">Alumni</h1>
   <% if @alumni.length > 0 %>
+  <div style="overflow-x:auto, overflow-y:visible">
     <table class="table table-borderless table-class">
       <thead>
         <th><h2>Name</h2></th>
@@ -160,9 +159,10 @@
         <% end %>
       </tbody>
     </table>
+  </div>
   <% else %>
     <p>No alumni.</p>
   <% end %>
-</div>
+
 
 </div>


### PR DESCRIPTION
This pull request corresponds to user story: [https://mchso-infoorganizer.atlassian.net/browse/MCHSO-42](url)

Description

As the organization, I want admins to be able to view a visually manage members page so they can easily edit the permissions and info of the organization members.

Acceptance Criteria:

-Is mobile and PC friendly

-Styling should be evident on each page

-color scheme consistent across pages

Definition of Done:

-Reviewed by the product owner

-100% code coverage

-Satisfies acceptance criteria

-Deployed on website