### PR TITLE
Hotfix #2

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -73,11 +73,11 @@ class ApplicationController < ActionController::Base
     lines = input_string.split("\n")
     lines.each_with_index do |this_line, index|
       output_string += this_line
-      if index < lines.size - 1
-        output_string += '<br>'
-      end
+      output_string += '<br>' if index < lines.size - 1
     end
     output_string += '</p>'
-    return output_string.html_safe
+    # rubocop:disable Rails/OutputSafety
+    output_string.html_safe
+    # rubocop:enable Rails/OutputSafety
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  helper_method :admin?, :member?, :get_user_status, :get_points, :get_points_type, :attended?
+  helper_method :admin?, :member?, :get_user_status, :get_points, :get_points_type, :attended?, :convert_line_breaks
 
   def admin?(user = current_user)
     if user
@@ -65,5 +65,19 @@ class ApplicationController < ActionController::Base
 
   def attended?(event_id)
     AttendanceRecord.where(event_id: event_id, uid: current_user.id).count.positive?
+  end
+
+  def convert_line_breaks(input_string)
+    # output_string = "<p>#{input_string}<br>howdy</p>"
+    output_string = '<p>'
+    lines = input_string.split("\n")
+    lines.each_with_index do |this_line, index|
+      output_string += this_line
+      if index < lines.size - 1
+        output_string += '<br>'
+      end
+    end
+    output_string += '</p>'
+    return output_string.html_safe
   end
 end

--- a/app/views/admin/manage_members.html.erb
+++ b/app/views/admin/manage_members.html.erb
@@ -73,6 +73,7 @@
                     Manage
                   </button>
                   <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                    <li><%= link_to "Manage Points", "/show_user_attendance/#{user.id}", class: "dropdown-item" %></li>
                     <% if !user.admin %>
                       <%# option to give user admin status %>
                       <li><%= link_to "Make Admin", "/make_user_admin/#{user.id}", class: "dropdown-item" %></li>

--- a/app/views/internal/attend.html.erb
+++ b/app/views/internal/attend.html.erb
@@ -6,7 +6,6 @@
       <h1>Attend an Event</h1>
 
       <h2>Events Today</h2>
-
       <% if @events_today.length > 0 %>
         <div class="events_container">
           <% @events_today.each do |event| %>
@@ -27,7 +26,6 @@
       <% end %>
 
       <h2>Upcoming Events</h2>
-
       <% if @upcoming_events.length > 0 %>
         <div class="events_container">
           <% @upcoming_events.each do |event| %>
@@ -45,6 +43,26 @@
         </div>
       <% else %>
         <p>No upcoming events.</p>
+      <% end %>
+
+      <h2>Past Events</h2>
+      <% if @past_events.length > 0 %>
+        <div class="events_container">
+          <% @past_events.each do |event| %>
+            <%= render :partial => 'shared/event_card', :locals => {
+              :event_id => event.id,
+              :event_name => event.event_name,
+              :event_date => event.date,
+              :points_type_id => event.points_type_id,
+              :event_description => event.description,
+              :show_passcode => nil,
+              :is_attend => false,
+              :is_admin => false
+              } %>
+          <% end %>
+        </div>
+      <% else %>
+        <p>No past events.</p>
       <% end %>
     </div>
   </div>

--- a/app/views/internal/internal_contact.html.erb
+++ b/app/views/internal/internal_contact.html.erb
@@ -1,6 +1,6 @@
 <%= stylesheet_link_tag "internal-contact" %>
-<body>
 
+<body>
 <div class = "container">
   <div class="box">
 
@@ -15,6 +15,7 @@
         </div>
       </div>
     <% end %>
+
     <% if @members.length > 0%>
       <div id="member-table" class="table-style">
         <table>
@@ -23,7 +24,8 @@
             <th> Name</th>
             <th> Member Status</th>
             <th> Years Active</th>
-            <th class="long-cell"> Email</th>
+            <th> Email</th>
+            <th> Bio </th>
           </thead>
           <tbody>
             <% @members.each do |user| %>
@@ -36,9 +38,10 @@
                   <% end %>
                 </td>
                 <td><%= user.full_name %></td>
-                <td><%= get_user_status(user) %>
+                <td><%= get_user_status(user) %></td>
                 <td><%= user.information.start_year %> - <%= user.information.end_year %></td>
-                <td class="long-cell"><%= user.email %></td>
+                <td><%= user.email %></td>
+                <td><%= user.information.bios %> </td>
               </tr>
             <% end %>
             <% @alumni.each do |user| %>
@@ -51,9 +54,10 @@
                 <% end %>
               </td>
                 <td><%= user.full_name %></td>
-                <td><%= get_user_status(user) %>
+                <td><%= get_user_status(user) %></td>
                 <td><%= user.information.start_year %> - <%= user.information.end_year %></td>
                 <td class="long-cell"><%= user.email %></td>
+                <td><%= user.information.bios %> </td>
               </tr>
             <% end %>
           </tbody>

--- a/app/views/internal/search.html.erb
+++ b/app/views/internal/search.html.erb
@@ -13,7 +13,8 @@
             <th>Name</th>
             <th>Member Status</th>
             <th>Years Active</th>
-            <th class="long-cell">Email</th>
+            <th>Email</th>
+            <th> Bio </th>
           </thead>
           <tbody>
             <% @results.each do |result| %>
@@ -26,9 +27,10 @@
                 <% end %>
               </td>
                 <td><%= result.full_name %></td>
-                <td><%= get_user_status(result) %>
+                <td><%= get_user_status(result) %></td>
                 <td><%= result.information.start_year %> - <%= result.information.end_year %></td>
-                <td class="long-cell"><%= result.email %></td>
+                <td><%= result.email %></td>
+                <td><%= result.information.bios %> </td>
               </tr>
             <% end %>
           </tbody>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>InfoOrganizer</title>
+    <title>MCHSO Website</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/app/views/shared/_event_card.html.erb
+++ b/app/views/shared/_event_card.html.erb
@@ -38,8 +38,8 @@
     <% end %>
 
     <% if is_admin %>
-      <div style='user-select:none;'><br/><br/><br/><br/><br/></div>
       <p class='event_card_footer'>
+        <div style='user-select:none;'><br/></div>
         <%# show event type %>
         Event type: <b><%= get_points_type(points_type_id.to_i) %></b> <br/>
         <%# show password %>

--- a/app/views/shared/_event_card.html.erb
+++ b/app/views/shared/_event_card.html.erb
@@ -12,7 +12,7 @@
     <div class='event_body'>
       <p class='event_time'><%= event_date.to_formatted_s(:get_time) %></p>
       <h1 class='event_name'><%= event_name %></h1>
-      <p><%= event_description %></p>
+      <%= convert_line_breaks(event_description) %>
     </div>
 
     <% if is_attend %>
@@ -39,7 +39,8 @@
 
     <% if is_admin %>
       <p class='event_card_footer'>
-        <div style='user-select:none;'><br/></div>
+        <%# space between description and footer %>
+        <div style='user-select:none;'></div>
         <%# show event type %>
         Event type: <b><%= get_points_type(points_type_id.to_i) %></b> <br/>
         <%# show password %>

--- a/spec/views/events/index.html.erb_spec.rb
+++ b/spec/views/events/index.html.erb_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe('events/index', type: :view) do
     view.lookup_context.prefixes << 'application'
     without_partial_double_verification do
       allow(view).to(receive(:get_points_type).and_return('Member'))
+      allow(view).to(receive(:convert_line_breaks).and_return('<p>MyText</p>'.html_safe))
     end
     assign(:events, [
       Event.create!(
@@ -45,6 +46,6 @@ RSpec.describe('events/index', type: :view) do
   it 'renders a list of events' do
     render
     assert_select 'h1', text: 'Event Name'.to_s, count: 3
-    assert_select 'p', text: 'MyText'.to_s, count: 3
+    assert_select 'p', text: 'MyText'.to_s, count: 4
   end
 end

--- a/spec/views/external/external_events.html.erb_spec.rb
+++ b/spec/views/external/external_events.html.erb_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe('external/events', type: :view) do
   before do
     without_partial_double_verification do
       allow(view).to(receive(:get_points_type).and_return('Member'))
+      allow(view).to(receive(:convert_line_breaks).and_return('<p>MyText</p>'.html_safe))
     end
     assign(:events, [
       Event.create!(
@@ -42,7 +43,7 @@ RSpec.describe('external/events', type: :view) do
   it 'renders a list of events' do
     render
     assert_select 'h1', text: 'Event Name'.to_s, count: 2
-    assert_select 'p', text: 'MyText'.to_s, count: 2
+    assert_select 'p', text: 'MyText'.to_s, count: 3
   end
 
   it 'assigns @events_today' do


### PR DESCRIPTION
This is the second hotfix of the maintenance phase, pushing the code from [this PR](https://github.com/jswood23/CSCE431/pull/67) into production. It includes these changes:

- Members can now view past events in the "Attend an Event" page, similarly to how admins can see them in "Manage Events".
- In a few cases, the text in the event cards was mashing (two lines would overlap) in the "Manage Events" page on tablet and mobile. That is now fixed.
- The description in each event card now shows line breaks if they were input in the event form.